### PR TITLE
fix: Vercelビルド時にPrismaクライアントが生成されない問題を修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "prisma generate && next build",
     "start": "next start",
     "lint": "next lint"
   },


### PR DESCRIPTION
ビルドスクリプトに `prisma generate` を追加することで、
Vercelのビルド環境でも `app/generated/prisma/` が生成されるようにした。